### PR TITLE
[DEFAULT] 비즈니스 별 발생할 수 있는 에러 코드 정의 및 관리 체계 구축 / 프레임워크별 글로벌 에러 핸들러를 통해 예외 로깅 및 응답 처리 핸들러 구현

### DIFF
--- a/src/main/java/com/hhplus/concert/core/domain/concert/ConcertSchedule.java
+++ b/src/main/java/com/hhplus/concert/core/domain/concert/ConcertSchedule.java
@@ -1,10 +1,13 @@
 package com.hhplus.concert.core.domain.concert;
 
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ExceptionCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.boot.logging.LogLevel;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -50,7 +53,7 @@ public class ConcertSchedule {
 
     public void isSoldOutCheck() {
         if(this.totalSeatStatus != TotalSeatStatus.AVAILABLE) {
-            throw new IllegalArgumentException("죄송합니다. 해당 콘서트는 모든 좌석이 매진된 콘서트입니다.");
+            throw new ApiException(ExceptionCode.E002, LogLevel.INFO);
         }
     }
 }

--- a/src/main/java/com/hhplus/concert/core/domain/concert/ConcertSeat.java
+++ b/src/main/java/com/hhplus/concert/core/domain/concert/ConcertSeat.java
@@ -1,10 +1,13 @@
 package com.hhplus.concert.core.domain.concert;
 
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ExceptionCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.boot.logging.LogLevel;
 
 import java.time.LocalDateTime;
 
@@ -43,7 +46,7 @@ public class ConcertSeat {
 
     public void isReserveCheck() {
         if(this.seatStatus != SeatStatus.AVAILABLE) {
-            throw new IllegalArgumentException("해당 좌석은 예약할 수 없는 상태 입니다.");
+            throw new ApiException(ExceptionCode.E004, LogLevel.ERROR);
         } else {
             this.seatStatus = SeatStatus.TEMP_RESERVED;
         }

--- a/src/main/java/com/hhplus/concert/core/domain/queue/Queue.java
+++ b/src/main/java/com/hhplus/concert/core/domain/queue/Queue.java
@@ -1,11 +1,14 @@
 package com.hhplus.concert.core.domain.queue;
 
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ExceptionCode;
 import io.jsonwebtoken.Jwts;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.boot.logging.LogLevel;
 
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -68,7 +71,7 @@ public class Queue {
 
     public void tokenReserveCheck() {
         if(this.status != QueueStatus.PROGRESS) {
-            throw new IllegalArgumentException("정상적인 프로세스로 접근하지 않았습니다. 다시 대기열에 접근해주세요.");
+            throw new ApiException(ExceptionCode.E001, LogLevel.ERROR);
         }
     }
 
@@ -101,7 +104,7 @@ public class Queue {
             this.enteredDt  = expiredDt;
         } else {
             if(this.getStatus() == QueueStatus.EXPIRED) {
-                throw new IllegalArgumentException("대기열 상태가 활성상태가 아닙니다.");
+                throw new ApiException(ExceptionCode.E003, LogLevel.ERROR);
             }
         }
     }

--- a/src/main/java/com/hhplus/concert/core/domain/user/Users.java
+++ b/src/main/java/com/hhplus/concert/core/domain/user/Users.java
@@ -1,11 +1,14 @@
 package com.hhplus.concert.core.domain.user;
 
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ExceptionCode;
 import io.jsonwebtoken.Jwts;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.boot.logging.LogLevel;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -67,7 +70,7 @@ public class Users {
 
     public void checkConcertAmount(Long seatAmount) {
         if(this.userAmount < seatAmount) {
-            throw new IllegalArgumentException("유저의 잔액이 부족합니다!");
+            throw new ApiException(ExceptionCode.E005, LogLevel.INFO);
         }
         this.userAmount -= seatAmount;
     }

--- a/src/main/java/com/hhplus/concert/core/infrastructure/repository/concert/repository/ConcertRepositoryImpl.java
+++ b/src/main/java/com/hhplus/concert/core/infrastructure/repository/concert/repository/ConcertRepositoryImpl.java
@@ -16,7 +16,7 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     @Override
     public Concert findById(Long concertId) {
         return jpaRepository.findById(concertId).orElseThrow(
-                () -> new IllegalArgumentException("해당 아이디를 가진 콘서트가 존재하지 않습니다."));
+                () -> new NullPointerException("해당 아이디를 가진 콘서트가 존재하지 않습니다."));
     }
 
     @Override

--- a/src/main/java/com/hhplus/concert/core/infrastructure/repository/concert/repository/ConcertScheduleRepositoryImpl.java
+++ b/src/main/java/com/hhplus/concert/core/infrastructure/repository/concert/repository/ConcertScheduleRepositoryImpl.java
@@ -22,7 +22,7 @@ public class ConcertScheduleRepositoryImpl implements ConcertScheduleRepository 
     @Override
     public ConcertSchedule findById(long scheduleId) {
         return jpaRepository.findById(scheduleId).orElseThrow(
-                () -> new IllegalArgumentException("해당 아이디를 가진 콘서트 스케쥴이 존재하지 않습니다."));
+                () -> new NullPointerException("해당 아이디를 가진 콘서트 스케쥴이 존재하지 않습니다."));
     }
 
     @Override

--- a/src/main/java/com/hhplus/concert/core/infrastructure/repository/concert/repository/PaymentRepositoryImpl.java
+++ b/src/main/java/com/hhplus/concert/core/infrastructure/repository/concert/repository/PaymentRepositoryImpl.java
@@ -21,7 +21,7 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     @Override
     public Payment findByReservationId(Long id) {
         return jpaRepository.findByReservationId(id).orElseThrow(
-                () -> new IllegalArgumentException("해당 예약 아이디의 결제정보가 존재하지 않습니다.")
+                () -> new NullPointerException("해당 예약 아이디의 결제정보가 존재하지 않습니다.")
         );
     }
 

--- a/src/main/java/com/hhplus/concert/core/infrastructure/repository/concert/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/hhplus/concert/core/infrastructure/repository/concert/repository/ReservationRepositoryImpl.java
@@ -21,7 +21,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     @Override
     public Reservation findById(long reservationId) {
         return jpaRepository.findById(reservationId).orElseThrow(
-                () -> new IllegalArgumentException("해당 예약 정보가 존재하지 않습니다.")
+                () -> new NullPointerException("해당 예약 정보가 존재하지 않습니다.")
         );
     }
 

--- a/src/main/java/com/hhplus/concert/core/infrastructure/repository/queue/repository/QueueRepositoryImpl.java
+++ b/src/main/java/com/hhplus/concert/core/infrastructure/repository/queue/repository/QueueRepositoryImpl.java
@@ -40,7 +40,7 @@ public class QueueRepositoryImpl implements QueueRepository {
     @Override
     public Queue findByToken(String token) {
         return jpaRepository.findByToken(token)
-                .orElseThrow(() -> new IllegalArgumentException("해당 토큰의 큐가 존재하지 않습니다."));
+                .orElseThrow(() -> new NullPointerException("해당 토큰의 큐가 존재하지 않습니다."));
     }
 
     @Override

--- a/src/main/java/com/hhplus/concert/core/infrastructure/repository/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/hhplus/concert/core/infrastructure/repository/user/repository/UserRepositoryImpl.java
@@ -20,12 +20,12 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public Users findById(long userId) {
         return userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 id의 유저가 존재하지 않습니다."));
+                .orElseThrow(() -> new NullPointerException("해당 id의 유저가 존재하지 않습니다."));
     }
 
     @Override
     public Users findByIdWithLock(long userId) {
         return userJpaRepository.findByIdWithLock(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 id의 유저가 존재하지 않습니다."));
+                .orElseThrow(() -> new NullPointerException("해당 id의 유저가 존재하지 않습니다."));
     }
 }

--- a/src/main/java/com/hhplus/concert/core/interfaces/api/common/CommonRes.java
+++ b/src/main/java/com/hhplus/concert/core/interfaces/api/common/CommonRes.java
@@ -1,8 +1,14 @@
 package com.hhplus.concert.core.interfaces.api.common;
 
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ExceptionCode;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ExceptionMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.http.HttpStatus;
 
 import java.util.HashMap;
+
+import static com.hhplus.concert.core.interfaces.api.common.ResultType.FAIL;
+import static com.hhplus.concert.core.interfaces.api.common.ResultType.SUCCESS;
 
 public record CommonRes<T>(
         @Schema(description = "반환 결과")
@@ -10,22 +16,26 @@ public record CommonRes<T>(
         @Schema(description = "반환 데이터")
         T data,
         @Schema(description = "반환 메시지", defaultValue = "SUCCESS or error 메시지")
-        String message
+        ExceptionMessage exception
 ) {
     @Override
     public String toString() {
         return "{\"CommonRes\":{"
                 + "        \"resultType\":\"" + resultType + "\""
                 + ",         \"data\":" + data
-                + ",         \"message\":\"" + message + "\""
+                + ",         \"exception\":\"" + exception + "\""
                 + "}}";
     }
 
     public static <T> CommonRes<T> success(T data) {
-        return new CommonRes<>(ResultType.SUCCESS, data, "SUCCESS");
+        return new CommonRes<>(SUCCESS, data, new ExceptionMessage());
     }
 
-    public static CommonRes<?> error(Exception e) {
-        return new CommonRes<>(ResultType.FAIL, new HashMap<>(), e.getMessage());
+    public static CommonRes<?> error(Exception error, HttpStatus status) {
+        return new CommonRes<>(FAIL, new HashMap<>(), new ExceptionMessage(error, status));
+    }
+
+    public static CommonRes<?> error(ExceptionCode error, Object errorData) {
+        return new CommonRes<>(FAIL, new HashMap<>(), new ExceptionMessage(error, errorData));
     }
 }

--- a/src/main/java/com/hhplus/concert/core/interfaces/api/surppot/ApiControllerAdvice.java
+++ b/src/main/java/com/hhplus/concert/core/interfaces/api/surppot/ApiControllerAdvice.java
@@ -1,0 +1,43 @@
+package com.hhplus.concert.core.interfaces.api.surppot;
+
+import com.hhplus.concert.core.interfaces.api.common.CommonRes;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ExceptionCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RestControllerAdvice
+@Slf4j
+public class ApiControllerAdvice {
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<CommonRes<?>> handleCoreApiException(ApiException e) {
+        switch (e.getLogLevel()) {
+            case ERROR -> log.error("ApiException : {}", e.getMessage(), e);
+            case WARN -> log.warn("ApiException : {}", e.getMessage(), e);
+            default -> log.info("ApiException : {}", e.getMessage(), e);
+        }
+        return new ResponseEntity<>(CommonRes.error(e.getExceptionCode(), e.getData()), OK);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonRes<?>> handleCoreApiException(IllegalArgumentException e) {
+        log.info("IllegalArgumentException : {}", e.getMessage(), e);
+        return new ResponseEntity<>(CommonRes.error(e, BAD_REQUEST), BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<CommonRes<?>> handleCoreApiException(NullPointerException e) {
+        log.info("NullPointerException : {}", e.getMessage(), e);
+        return new ResponseEntity<>(CommonRes.error(e, INTERNAL_SERVER_ERROR), INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonRes<?>> handleException(Exception e) {
+        log.error("Exception : {}", e.getMessage(), e);
+        return new ResponseEntity<>(CommonRes.error(ExceptionCode.E500, INTERNAL_SERVER_ERROR), INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/hhplus/concert/core/interfaces/api/surppot/exception/ApiException.java
+++ b/src/main/java/com/hhplus/concert/core/interfaces/api/surppot/exception/ApiException.java
@@ -1,0 +1,21 @@
+package com.hhplus.concert.core.interfaces.api.surppot.exception;
+
+import lombok.Getter;
+import org.springframework.boot.logging.LogLevel;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    private final LogLevel logLevel;
+
+    private final Object data;
+
+    public ApiException(ExceptionCode exceptionCode, LogLevel logLevel) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+        this.logLevel = logLevel;
+        this.data = null;
+    }
+}

--- a/src/main/java/com/hhplus/concert/core/interfaces/api/surppot/exception/ExceptionCode.java
+++ b/src/main/java/com/hhplus/concert/core/interfaces/api/surppot/exception/ExceptionCode.java
@@ -1,0 +1,21 @@
+package com.hhplus.concert.core.interfaces.api.surppot.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionCode {
+    E001("001", "정상적인 프로세스로 접근하지 않았습니다. 다시 대기열에 접근해주세요."),
+    E002("002", "죄송합니다. 해당 콘서트는 모든 좌석이 매진된 콘서트입니다."),
+    E003("003", "대기열 상태가 활성상태가 아닙니다."),
+    E004("004", "해당 좌석은 예약할 수 없는 상태 입니다."),
+    E005("005", "유저의 잔액이 부족합니다 잔액을 다시 확인해주세요!"),
+
+    E404("404", "데이터를 조회할 수 없습니다."),
+    E500("500", "알 수 없는 문제가 발생했습니다. 관리자에게 문의 부탁드립니다.");
+
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/hhplus/concert/core/interfaces/api/surppot/exception/ExceptionMessage.java
+++ b/src/main/java/com/hhplus/concert/core/interfaces/api/surppot/exception/ExceptionMessage.java
@@ -1,0 +1,32 @@
+package com.hhplus.concert.core.interfaces.api.surppot.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@Getter
+@JsonInclude(NON_NULL)
+public class ExceptionMessage {
+
+    private String code;
+    private String message;
+    private Object data;
+
+    // 빈 객체로 반환하기 위한 기본 생성자 추가
+    public ExceptionMessage() {
+    }
+
+    public ExceptionMessage(Exception exception, HttpStatus httpStatus) {
+        this.code = httpStatus.toString();
+        this.message = exception.getMessage();
+        this.data = null;
+    }
+
+    public ExceptionMessage(ExceptionCode exceptionCode, Object data) {
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getMessage();
+        this.data = data;
+    }
+}

--- a/src/test/java/com/hhplus/concert/core/domain/concert/ConcertServiceIntegrationTest.java
+++ b/src/test/java/com/hhplus/concert/core/domain/concert/ConcertServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import com.hhplus.concert.core.domain.queue.QueueRepository;
 import com.hhplus.concert.core.domain.queue.QueueStatus;
 import com.hhplus.concert.core.domain.user.UserRepository;
 import com.hhplus.concert.core.domain.user.Users;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -100,7 +101,7 @@ public class ConcertServiceIntegrationTest extends IntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> concertService.reserveConcert(token, concertSchedule.getId(), concertSeat.getId()))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ApiException.class)
                 .hasMessage("해당 좌석은 예약할 수 없는 상태 입니다.");
     }
 
@@ -123,7 +124,7 @@ public class ConcertServiceIntegrationTest extends IntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> concertService.reserveConcert(token, concertSchedule.getId(), concertSeat.getId()))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ApiException.class)
                 .hasMessage("죄송합니다. 해당 콘서트는 모든 좌석이 매진된 콘서트입니다.");
     }
 }

--- a/src/test/java/com/hhplus/concert/core/domain/concert/ConcertServiceUnitTest.java
+++ b/src/test/java/com/hhplus/concert/core/domain/concert/ConcertServiceUnitTest.java
@@ -1,5 +1,6 @@
 package com.hhplus.concert.core.domain.concert;
 
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -35,7 +36,7 @@ public class ConcertServiceUnitTest {
         ConcertSchedule concertSchedule = new ConcertSchedule(1L, 1L, LocalDate.now(), LocalDateTime.now().plusHours(1), LocalDateTime.now().plusHours(3), 100, 0, TotalSeatStatus.SOLD_OUT, LocalDateTime.now(), false);
 
         // when & then
-        assertThrows(IllegalArgumentException.class, concertSchedule::isSoldOutCheck);
+        assertThrows(ApiException.class, concertSchedule::isSoldOutCheck);
     }
 
     @Test
@@ -53,7 +54,7 @@ public class ConcertServiceUnitTest {
         ConcertSeat concertSeat = new ConcertSeat(1L, 1L, 500L, 10, SeatStatus.RESERVED, null, LocalDateTime.now(), false);
 
         // when & then
-        assertThrows(IllegalArgumentException.class, concertSeat::isReserveCheck, "해당 좌석은 예약할 수 없는 상태 입니다.");
+        assertThrows(ApiException.class, concertSeat::isReserveCheck, "해당 좌석은 예약할 수 없는 상태 입니다.");
     }
 
     @Test
@@ -62,6 +63,6 @@ public class ConcertServiceUnitTest {
         ConcertSeat concertSeat = new ConcertSeat(1L, 1L, 500L, 10, SeatStatus.TEMP_RESERVED, null, LocalDateTime.now(), false);
 
         // when & then
-        assertThrows(IllegalArgumentException.class, concertSeat::isReserveCheck, "해당 좌석은 예약할 수 없는 상태 입니다.");
+        assertThrows(ApiException.class, concertSeat::isReserveCheck, "해당 좌석은 예약할 수 없는 상태 입니다.");
     }
 }

--- a/src/test/java/com/hhplus/concert/core/domain/queue/EnterQueueIntegrationTest.java
+++ b/src/test/java/com/hhplus/concert/core/domain/queue/EnterQueueIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.hhplus.concert.core.domain.queue;
 
 import com.hhplus.concert.IntegrationTest;
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -122,7 +123,7 @@ public class EnterQueueIntegrationTest extends IntegrationTest {
 
         // when & then: 상태가 만료(EXPIRED)된 유저가 접근하면 예외 발생
         assertThatThrownBy(() -> queueService.checkQueue(expiredQueue.getToken()))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ApiException.class)
                 .hasMessage("대기열 상태가 활성상태가 아닙니다.");
     }
 }

--- a/src/test/java/com/hhplus/concert/core/domain/user/UsersUnitTest.java
+++ b/src/test/java/com/hhplus/concert/core/domain/user/UsersUnitTest.java
@@ -1,5 +1,6 @@
 package com.hhplus.concert.core.domain.user;
 
+import com.hhplus.concert.core.interfaces.api.surppot.exception.ApiException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -25,7 +26,7 @@ class UsersUnitTest {
 
         // when & then
         assertThatThrownBy(() ->  user.checkConcertAmount(2000L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("유저의 잔액이 부족합니다!");
+                .isInstanceOf(ApiException.class)
+                .hasMessage("유저의 잔액이 부족합니다 잔액을 다시 확인해주세요!");
     }
 }


### PR DESCRIPTION
# 작업내용
## 비즈니스 별 발생할 수 있는 에러코드 정의 및 관리체계 구축

- 커스텀 exception 을 생성하여 비즈니스별로 발생할 수 있는 에러코드를 정의하고,
   해당 에러 발생시 사용자에게 전달 할 메시지를 정의했습니다.

![image](https://github.com/user-attachments/assets/72d1a324-e1f1-43d7-aebd-6e1dc3cd013f)
### [ApiException.java](https://github.com/Cheondongmin/hhplus-concert-java/blob/week5/interceptor/src/main/java/com/hhplus/concert/core/interfaces/api/support/exception/ApiException.java)

![image](https://github.com/user-attachments/assets/e6c415b4-c422-4cca-a464-d766575d6dee)
### [ExceptionCode.java](https://github.com/Cheondongmin/hhplus-concert-java/blob/week5/interceptor/src/main/java/com/hhplus/concert/core/interfaces/api/support/exception/ExceptionCode.java)

## 프레임워크별 글로벌 에러 핸들러를 통해 예외 로깅 및 응답 처리 핸들러 구현

- RestControllerAdvice 를 사용하여 에러를 핸들링 할 수 있는 핸들러를 구성했습니다.
   로그레벨 조정 및 에러에 맞는 http status 로 response 될 수 있게 정의하였습니다.

![image](https://github.com/user-attachments/assets/352d8791-cfc8-42b9-8960-3bf2b6614711)
(에러에 맞는 http status 넘겨주는 부분은 step09 부분 브랜치에 구현 해놓았습니다..)

### [ApiControllerAdvice.java](https://github.com/Cheondongmin/hhplus-concert-java/blob/week5/interceptor/src/main/java/com/hhplus/concert/core/interfaces/api/support/ApiControllerAdvice.java)



